### PR TITLE
feat: Add logging for pruning in coordinator

### DIFF
--- a/crates/coordinator/src/main.rs
+++ b/crates/coordinator/src/main.rs
@@ -65,7 +65,14 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         loop {
             let mut cluster = cluster2.lock().await;
             let now = Utc::now().timestamp();
-            cluster.retain(|_, w| now - w.last_seen < 30);
+            cluster.retain(|worker_id, w| {
+                if now - w.last_seen < 30 {
+                    true // Keep the worker
+                } else {
+                    println!("Pruning dead worker: {}", worker_id); // Log removal
+                    false // Remove the worker
+                }
+            });
             sleep(Duration::from_secs(10)).await;
         }
     });


### PR DESCRIPTION
This commit introduces a log message in the coordinator's pruning task. When an inactive component is removed (i.e., missed heartbeats beyond the configured threshold), I will now log this event, including the ID of the component being pruned.

This change addresses the final part of the initial cluster control plane setup, ensuring that all specified milestones are met:
1. Registration: I log new connections.
2. Heartbeat Mechanism: I log received heartbeats.
3. Dead Component Pruning: I now log the removal of stale components.

The core logic for registration, heartbeats, and pruning was already present. This commit primarily enhances observability of the pruning process.