### PR TITLE
feat: Implement initial LogicalPlan for query engine

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -346,9 +346,9 @@ checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hashbrown"
-version = "0.15.3"
+version = "0.15.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84b26c544d002229e640969970a2e74021aadf6e2f96372b9c58eff97de08eb3"
+checksum = "5971ac85611da7067dbfcabef3c70ebb5606018acd9e2a3903a0da507521e0d5"
 
 [[package]]
 name = "heck"
@@ -560,6 +560,7 @@ dependencies = [
  "igloo-common",
  "prost",
  "prost-types",
+ "sqlparser",
  "tokio",
  "tonic",
 ]
@@ -595,7 +596,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cea70ddb795996207ad57735b50c5982d8844f38ba9ee5f1aedcfb708a2aa11e"
 dependencies = [
  "equivalent",
- "hashbrown 0.15.3",
+ "hashbrown 0.15.4",
 ]
 
 [[package]]
@@ -872,6 +873,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "psm"
+version = "0.1.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e944464ec8536cd1beb0bbfd96987eb5e3b72f2ecdafdc5c769a37f1fa2ae1f"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "pyigloo"
 version = "0.1.0"
 
@@ -918,6 +928,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom 0.2.16",
+]
+
+[[package]]
+name = "recursive"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0786a43debb760f491b1bc0269fe5e84155353c67482b9e60d0cfb596054b43e"
+dependencies = [
+ "recursive-proc-macro-impl",
+ "stacker",
+]
+
+[[package]]
+name = "recursive-proc-macro-impl"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76009fbe0614077fc1a2ce255e3a1881a2e3a3527097d5dc6d8212c585e7e38b"
+dependencies = [
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1047,6 +1077,29 @@ checksum = "e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678"
 dependencies = [
  "libc",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "sqlparser"
+version = "0.56.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e68feb51ffa54fc841e086f58da543facfe3d7ae2a60d69b0a8cbbd30d16ae8d"
+dependencies = [
+ "log",
+ "recursive",
+]
+
+[[package]]
+name = "stacker"
+version = "0.1.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cddb07e32ddb770749da91081d8d0ac3a16f1a569a18b20348cd371f5dead06b"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "libc",
+ "psm",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/crates/engine/Cargo.toml
+++ b/crates/engine/Cargo.toml
@@ -9,3 +9,4 @@ tokio = { workspace = true }
 tonic = { workspace = true }
 prost = { workspace = true }
 prost-types = { workspace = true }
+sqlparser = "0.56.0"

--- a/crates/engine/src/lib.rs
+++ b/crates/engine/src/lib.rs
@@ -10,10 +10,58 @@
 //! # TODO
 //! Implement query engine logic
 
+pub mod logical_plan;
+pub use logical_plan::{create_logical_plan, LogicalPlan};
+
 #[cfg(test)]
 mod tests {
+    use super::*; // To bring create_logical_plan and LogicalPlan into scope
+    use sqlparser::dialect::GenericDialect;
+    use sqlparser::parser::Parser;
+
     #[test]
     fn sample_test() {
         assert_eq!(2 + 2, 4);
+    }
+
+    #[test]
+    fn test_create_logical_plan() {
+        let sql = "SELECT a FROM my_table WHERE b > 10";
+
+        // Parse the SQL string using sqlparser
+        let dialect = GenericDialect {}; // Or any other dialect
+        let ast_statements = Parser::parse_sql(&dialect, sql).unwrap();
+
+        // We expect a single statement for this test SQL
+        assert_eq!(ast_statements.len(), 1, "Expected one SQL statement");
+        let ast = ast_statements.into_iter().next().unwrap();
+
+        // This is the function you need to implement (already done)
+        let logical_plan = create_logical_plan(ast).unwrap();
+
+        // Verify the plan has the correct structure
+        // Projection -> Filter -> TableScan
+        match logical_plan {
+            LogicalPlan::Projection { expr, input } => {
+                // Check projection expressions (optional, but good for thoroughness)
+                assert_eq!(expr, vec!["a".to_string()]);
+                match *input {
+                    LogicalPlan::Filter { predicate, input } => {
+                        // Check predicate (optional)
+                        assert_eq!(predicate, "b > 10".to_string()); // Based on current simple string representation
+                        match *input {
+                            LogicalPlan::TableScan { table_name } => {
+                                // Check table name (optional)
+                                assert_eq!(table_name, "my_table".to_string());
+                                // The structure is correct if we reach here
+                            }
+                            _ => panic!("Expected TableScan, got {:?}", *input),
+                        }
+                    }
+                    _ => panic!("Expected Filter, got {:?}", *input),
+                }
+            }
+            _ => panic!("Expected Projection, got {:?}", logical_plan),
+        }
     }
 }

--- a/crates/engine/src/logical_plan.rs
+++ b/crates/engine/src/logical_plan.rs
@@ -1,0 +1,102 @@
+// In crates/engine/src/logical_plan.rs
+
+// A logical plan represents a query in a tree-like structure.
+#[derive(Debug, PartialEq)] // Added Debug and PartialEq for easier testing
+pub enum LogicalPlan {
+    // A projection (e.g., SELECT a, b)
+    Projection {
+        // The expressions to project
+        expr: Vec<String>, // For now, we'll keep it simple with strings
+        // The input plan
+        input: Box<LogicalPlan>,
+    },
+    // A filter (e.g., WHERE a > 10)
+    Filter {
+        // The filter expression
+        predicate: String, // Simple string representation for now
+        // The input plan
+        input: Box<LogicalPlan>,
+    },
+    // A scan from a table (e.g., FROM table_1)
+    TableScan {
+        table_name: String,
+    },
+}
+
+use sqlparser::ast::{SelectItem, SetExpr, Statement, TableFactor};
+
+// (Keep the existing LogicalPlan enum definition here)
+
+pub fn create_logical_plan(statement: Statement) -> Result<LogicalPlan, String> {
+    match statement {
+        Statement::Query(query) => {
+            // Currently, we only support simple SELECT queries
+            if query.with.is_some() {
+                return Err("WITH clauses are not supported".to_string());
+            }
+            if query.order_by.is_some() {
+                // Check if there's any OrderBy object
+                return Err("ORDER BY clauses are not supported".to_string());
+            }
+            // ... (add more checks for unsupported features if necessary)
+
+            match *query.body {
+                SetExpr::Select(select_statement) => {
+                    // 1. Determine the input: TableScan
+                    // Expecting a single table in the FROM clause
+                    if select_statement.from.len() != 1 {
+                        return Err("Query must involve exactly one table".to_string());
+                    }
+                    let table_with_joins = &select_statement.from[0];
+                    if !table_with_joins.joins.is_empty() {
+                        return Err("JOIN clauses are not supported".to_string());
+                    }
+
+                    let table_name = match &table_with_joins.relation {
+                        TableFactor::Table { name, .. } => name.to_string(),
+                        _ => return Err("Expected a simple table name".to_string()),
+                    };
+
+                    let mut plan = LogicalPlan::TableScan { table_name };
+
+                    // 2. Apply Filter if WHERE clause exists
+                    if let Some(predicate_expr) = select_statement.selection {
+                        // For now, represent the predicate as a simple string
+                        // In a real engine, this would be a complex expression tree
+                        plan = LogicalPlan::Filter {
+                            predicate: format!("{}", predicate_expr), // Simplistic representation
+                            input: Box::new(plan),
+                        };
+                    }
+
+                    // 3. Apply Projection
+                    let projection_exprs: Vec<String> = select_statement
+                        .projection
+                        .into_iter()
+                        .map(|item| {
+                            match item {
+                                SelectItem::UnnamedExpr(expr) => format!("{}", expr), // Simplistic
+                                SelectItem::ExprWithAlias { expr, alias } => {
+                                    format!("{} AS {}", expr, alias)
+                                } // Simplistic
+                                SelectItem::QualifiedWildcard(..) => "*".to_string(), // Represent SELECT *
+                                SelectItem::Wildcard(_) => "*".to_string(), // Represent SELECT *
+                            }
+                        })
+                        .collect();
+
+                    if projection_exprs.is_empty() {
+                        return Err("Projection list cannot be empty".to_string());
+                    }
+
+                    plan =
+                        LogicalPlan::Projection { expr: projection_exprs, input: Box::new(plan) };
+
+                    Ok(plan)
+                }
+                _ => Err("Only SELECT queries are supported".to_string()),
+            }
+        }
+        _ => Err("Only Query statements are supported".to_string()),
+    }
+}


### PR DESCRIPTION
Adds the basic data structures for the Logical Plan representation (Projection, Filter, TableScan) in the `igloo-engine` crate.

Includes a `create_logical_plan` function that converts an AST (from `sqlparser-rs`) for simple SELECT queries (e.g., `SELECT a FROM t WHERE b > 1`) into this LogicalPlan structure.

The conversion handles:
- `SELECT <expressions>` as `Projection`
- `WHERE <predicate>` as `Filter`
- `FROM <table>` as `TableScan`

Expressions and predicates are currently represented as simple strings.

A unit test (`test_create_logical_plan`) is added to verify the correct nesting (Projection -> Filter -> TableScan) and content of the generated plan for a sample query.

This lays the groundwork for further query processing and optimization stages.