### PR TITLE
feat: Implement core execution engine

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -212,6 +212,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
+name = "csv"
+version = "1.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acdc4883a9c96732e4733212c01447ebd805833b7275a73ca3ee080fd77afdaf"
+dependencies = [
+ "csv-core",
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
+name = "csv-core"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d02f3b0da4c6504f86e9cd789d8dbafab48c2321be74e9987593de5a894d93d"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -346,9 +367,9 @@ checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hashbrown"
-version = "0.15.3"
+version = "0.15.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84b26c544d002229e640969970a2e74021aadf6e2f96372b9c58eff97de08eb3"
+checksum = "5971ac85611da7067dbfcabef3c70ebb5606018acd9e2a3903a0da507521e0d5"
 
 [[package]]
 name = "heck"
@@ -510,9 +531,11 @@ dependencies = [
 name = "igloo-connector-filesystem"
 version = "0.1.0"
 dependencies = [
+ "csv",
  "igloo-common",
  "prost",
  "prost-types",
+ "tempfile",
  "tokio",
  "tonic",
 ]
@@ -558,8 +581,10 @@ name = "igloo-engine"
 version = "0.1.0"
 dependencies = [
  "igloo-common",
+ "igloo-connector-filesystem",
  "prost",
  "prost-types",
+ "tempfile",
  "tokio",
  "tonic",
 ]
@@ -595,7 +620,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cea70ddb795996207ad57735b50c5982d8844f38ba9ee5f1aedcfb708a2aa11e"
 dependencies = [
  "equivalent",
- "hashbrown 0.15.3",
+ "hashbrown 0.15.4",
 ]
 
 [[package]]
@@ -982,6 +1007,12 @@ name = "rustversion"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a0d197bd2c9dc6e53b84da9556a69ba4cdfab8619eb41a8bd1cc2027a0f6b1d"
+
+[[package]]
+name = "ryu"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
 
 [[package]]
 name = "scopeguard"

--- a/crates/connectors/filesystem/Cargo.toml
+++ b/crates/connectors/filesystem/Cargo.toml
@@ -9,3 +9,7 @@ tokio = { version = "1", features = ["full"] }
 tonic = "0.10"
 prost = "0.12"
 prost-types = "0.12"
+csv = "1.1"
+
+[dev-dependencies]
+tempfile = "3.3"

--- a/crates/connectors/filesystem/src/lib.rs
+++ b/crates/connectors/filesystem/src/lib.rs
@@ -1,9 +1,76 @@
 // TODO: Implement filesystem connector logic
 
+use csv::ReaderBuilder;
+use std::fs::File;
+
+pub struct CsvTable {
+    pub path: String,
+}
+
+impl CsvTable {
+    pub fn new(path: String) -> Self {
+        Self { path }
+    }
+
+    pub fn scan(&self) -> Result<Box<dyn Iterator<Item = Vec<String>>>, String> {
+        let file = File::open(&self.path).map_err(|e| format!("Failed to open file: {}", e))?;
+
+        let mut rdr = ReaderBuilder::new().has_headers(false).from_reader(file);
+
+        let mut records = Vec::new();
+        for result in rdr.records() {
+            let record = result.map_err(|e| format!("Failed to parse CSV record: {}", e))?;
+            records.push(record.iter().map(|field| field.to_string()).collect());
+        }
+
+        Ok(Box::new(records.into_iter()))
+    }
+}
+
 #[cfg(test)]
 mod tests {
+    use super::*;
+    use std::io::Write;
+
     #[test]
-    fn sample_test() {
-        assert_eq!(2 + 2, 4);
+    fn test_csv_table_scan_success() {
+        let mut temp_file = tempfile::NamedTempFile::new().unwrap();
+        writeln!(temp_file, "1,a,x").unwrap();
+        writeln!(temp_file, "2,b,y").unwrap();
+        writeln!(temp_file, "3,c,z").unwrap();
+        temp_file.flush().unwrap();
+
+        let table = CsvTable::new(temp_file.path().to_str().unwrap().to_string());
+        let mut iter = table.scan().unwrap();
+
+        assert_eq!(iter.next(), Some(vec!["1".to_string(), "a".to_string(), "x".to_string()]));
+        assert_eq!(iter.next(), Some(vec!["2".to_string(), "b".to_string(), "y".to_string()]));
+        assert_eq!(iter.next(), Some(vec!["3".to_string(), "c".to_string(), "z".to_string()]));
+        assert_eq!(iter.next(), None);
+    }
+
+    #[test]
+    fn test_csv_table_scan_file_not_found() {
+        let table = CsvTable::new("non_existent_file.csv".to_string());
+        assert!(table.scan().is_err());
+    }
+
+    #[test]
+    fn test_csv_table_scan_invalid_csv() {
+        let mut temp_file = tempfile::NamedTempFile::new().unwrap();
+        writeln!(temp_file, "1,a,x").unwrap();
+        writeln!(temp_file, "2,b").unwrap(); // Invalid record
+        temp_file.flush().unwrap();
+
+        let table = CsvTable::new(temp_file.path().to_str().unwrap().to_string());
+        let result = table.scan();
+        // Depending on the csv library's behavior, this might or might not error on reading,
+        // but rather when iterating. For this setup, we check if it errors out during the scan setup.
+        // The exact behavior might need adjustment based on how errors are propagated.
+        // For now, let's assume the current implementation would error out when `collect()` is called internally
+        // or if the library is strict about record lengths from the start.
+        // This test might need refinement based on the chosen CSV parsing strategy and error handling.
+        // The current implementation reads all records into memory first, so it should catch this.
+        assert!(result.is_err());
     }
 }

--- a/crates/engine/Cargo.toml
+++ b/crates/engine/Cargo.toml
@@ -9,3 +9,7 @@ tokio = { workspace = true }
 tonic = { workspace = true }
 prost = { workspace = true }
 prost-types = { workspace = true }
+igloo-connector-filesystem = { path = "../connectors/filesystem" }
+
+[dev-dependencies]
+tempfile = "3.3"

--- a/crates/engine/src/lib.rs
+++ b/crates/engine/src/lib.rs
@@ -10,10 +10,141 @@
 //! # TODO
 //! Implement query engine logic
 
+use igloo_connector_filesystem::CsvTable; // Corrected import
+
+pub trait ExecutionPlan {
+    // Adjusted return type to include lifetime tied to `self`
+    fn execute(&self) -> Result<Box<dyn Iterator<Item = Vec<String>> + '_>, String>;
+}
+
+pub struct ScanExec {
+    pub path: String,
+}
+
+impl ExecutionPlan for ScanExec {
+    fn execute(&self) -> Result<Box<dyn Iterator<Item = Vec<String>> + '_>, String> {
+        let table = CsvTable::new(self.path.clone());
+        table.scan()
+    }
+}
+
+pub struct FilterExec {
+    pub input: Box<dyn ExecutionPlan>,
+    pub predicate: Box<dyn Fn(Vec<String>) -> bool>,
+}
+
+impl ExecutionPlan for FilterExec {
+    fn execute(&self) -> Result<Box<dyn Iterator<Item = Vec<String>> + '_>, String> {
+        let input_data = self.input.execute()?; // Renamed to avoid unused_variable warning if only used in closure
+
+        // predicate_ref is captured by the closure. The closure itself is 'move',
+        // but predicate_ref is a reference with the lifetime of `self`.
+        // By specifying `+ '_` in the return type, we allow this.
+        let predicate_ref = &self.predicate;
+        let filtered_iter =
+            input_data.filter(move |row: &Vec<String>| (*predicate_ref)(row.clone()));
+        Ok(Box::new(filtered_iter))
+    }
+}
+
+pub struct ProjectionExec {
+    pub input: Box<dyn ExecutionPlan>,
+    pub columns: Vec<usize>,
+}
+
+impl ExecutionPlan for ProjectionExec {
+    fn execute(&self) -> Result<Box<dyn Iterator<Item = Vec<String>> + '_>, String> {
+        let input_iter = self.input.execute()?;
+
+        // To handle lifetimes correctly for the returned Box<dyn Iterator>,
+        // especially if it needs to be 'static, we should ensure that data captured by
+        // the closure is also 'static. `self.columns` is `Vec<usize>`.
+        // If we capture `&self.columns`, the closure is tied to the lifetime of `self`.
+        // To make it 'static, we should clone `self.columns` and move the clone
+        // into the closure.
+        let columns_clone = self.columns.clone();
+
+        let projected_iter = input_iter.map(move |row: Vec<String>| {
+            let mut projected_row = Vec::with_capacity(columns_clone.len());
+            for &index in &columns_clone {
+                // .get(index) returns Option<&String>, then .cloned() to Option<String>
+                // .unwrap_or_default() handles out-of-bounds by providing a default String (empty).
+                // This is a simple way to handle potential out-of-bounds access,
+                // though a planner should ideally ensure indices are valid.
+                // Cloning is necessary as we are creating a new Vec<String> from owned values.
+                projected_row.push(row.get(index).cloned().unwrap_or_default());
+            }
+            projected_row
+        });
+
+        Ok(Box::new(projected_iter))
+    }
+}
+
 #[cfg(test)]
 mod tests {
+    use super::*; // Imports ExecutionPlan, ScanExec, FilterExec, ProjectionExec
+                  // use std::fs::File; // Removed unused import
+    use std::io::Write;
+    use tempfile::NamedTempFile;
+
     #[test]
     fn sample_test() {
         assert_eq!(2 + 2, 4);
+    }
+
+    #[test]
+    fn test_end_to_end_query() -> Result<(), String> {
+        // 1. Create a temporary CSV file
+        let mut temp_file =
+            NamedTempFile::new().map_err(|e| format!("Failed to create temp file: {}", e))?;
+        writeln!(temp_file, "id,name,score")
+            .map_err(|e| format!("Failed to write to temp file: {}", e))?;
+        writeln!(temp_file, "1,a,100")
+            .map_err(|e| format!("Failed to write to temp file: {}", e))?;
+        writeln!(temp_file, "2,b,80")
+            .map_err(|e| format!("Failed to write to temp file: {}", e))?;
+        writeln!(temp_file, "3,c,95")
+            .map_err(|e| format!("Failed to write to temp file: {}", e))?;
+        temp_file.flush().map_err(|e| format!("Failed to flush temp file: {}", e))?;
+        let file_path =
+            temp_file.path().to_str().ok_or("Temp file path is not valid UTF-8")?.to_string();
+
+        // 2. Manually Construct Physical Plan
+        let scan_exec = ScanExec { path: file_path };
+
+        let filter_exec = FilterExec {
+            input: Box::new(scan_exec),
+            predicate: Box::new(|row: Vec<String>| {
+                // Use .first() instead of .get(0) as per clippy recommendation
+                if row.first() == Some(&"id".to_string()) {
+                    // Skip header
+                    return false;
+                }
+                if let Some(score_str) = row.get(2) {
+                    if let Ok(score) = score_str.parse::<i32>() {
+                        return score > 90;
+                    }
+                }
+                false
+            }),
+        };
+
+        // ProjectionExec: project name (column 1)
+        let projection_exec = ProjectionExec {
+            input: Box::new(filter_exec),
+            columns: vec![1], // Index of the 'name' column
+        };
+
+        // 3. Execute the Query
+        let mut results_iter = projection_exec.execute()?;
+
+        // 4. Verify Results
+        assert_eq!(results_iter.next(), Some(vec!["a".to_string()]));
+        assert_eq!(results_iter.next(), Some(vec!["c".to_string()]));
+        assert_eq!(results_iter.next(), None);
+
+        // temp_file is automatically removed when it goes out of scope.
+        Ok(())
     }
 }


### PR DESCRIPTION
This commit introduces the core execution engine functionality within the `igloo-engine` crate. It defines the `ExecutionPlan` trait and implements it for `ScanExec`, `FilterExec`, and `ProjectionExec` nodes, establishing a pull-based (iterator) execution model.

Key changes:
- Defined `ExecutionPlan` trait in `crates/engine/src/lib.rs`.
- Implemented `ScanExec` to read data from CSV files using a new `CsvTable` component from `igloo-connectors-filesystem`.
- Implemented `FilterExec` to filter rows based on a predicate.
- Implemented `ProjectionExec` to select specific columns.
- Added `CsvTable` in `crates/connectors/filesystem/src/lib.rs` for CSV parsing.
- Included a comprehensive end-to-end integration test (`test_end_to_end_query`) in `crates/engine/src/lib.rs` that manually constructs a physical plan (Scan -> Filter -> Project) and verifies the results against a test CSV file.
- Addressed various lifetime, dependency, and clippy issues to ensure scripts `./scripts/setup.sh` and `./scripts/check.sh` pass.

This work forms the final critical piece of the single-node engine, enabling the execution of query plans and production of results.