### PR TITLE
Refine coordinator Flight SQL endpoints and add integration tests

### DIFF
--- a/crates/coordinator/Cargo.toml
+++ b/crates/coordinator/Cargo.toml
@@ -3,7 +3,16 @@ name = "igloo-coordinator"
 version = "0.1.0"
 edition = "2021"
 
+[lib]
+name = "igloo_coordinator" # Library name used for imports
+path = "src/lib.rs"
+
+[[bin]]
+name = "igloo-coordinator-bin" # Binary executable name
+path = "src/main.rs"
+
 [dependencies]
+futures = "0.3"
 igloo-api = { path = "../api" }
 igloo-common = { path = "../common" }
 igloo-engine = { path = "../engine" }

--- a/crates/coordinator/src/lib.rs
+++ b/crates/coordinator/src/lib.rs
@@ -1,0 +1,60 @@
+use datafusion::arrow::datatypes::{DataType, Field, Schema};
+use datafusion::datasource::file_format::csv::CsvFormat;
+use datafusion::datasource::listing::{
+    ListingOptions, ListingTable, ListingTableConfig, ListingTableUrl,
+};
+use igloo_engine::QueryEngine;
+use std::path::Path;
+use std::sync::Arc;
+use std::net::SocketAddr;
+
+use arrow_flight::flight_service_server::FlightServiceServer;
+use igloo_api::IglooFlightSqlService;
+use crate::service::CoordinatorFlightSqlService; // Adjusted path
+use tonic::transport::Server;
+
+pub mod service;
+
+// Extracted server launch logic
+pub async fn launch_coordinator(addr_override: Option<SocketAddr>) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    // 1. Instantiate the query engine
+    let engine = QueryEngine::new();
+
+    // 2. Register the CSV as a table (optional, could be moved or made configurable)
+    let csv_relative_path = "../connectors/filesystem/test_data.csv"; // Relative to workspace root
+    let base_path = std::env::current_dir()?;
+    let csv_abs_path = base_path.join(Path::new(csv_relative_path));
+    let table_path_url_str = format!("file://{}", csv_abs_path.display());
+    let table_path = ListingTableUrl::parse(&table_path_url_str)?;
+    println!("Attempting to register test_table from lib.rs with path: {}", csv_abs_path.display());
+    let config = ListingTableConfig::new(table_path)
+        .with_schema(Arc::new(Schema::new(vec![
+            Field::new("col_a", DataType::Int64, false),
+            Field::new("col_b", DataType::Utf8, false),
+        ])))
+        .with_listing_options(
+            ListingOptions::new(Arc::new(CsvFormat::default().with_has_header(true)))
+                .with_file_extension(".csv"),
+        );
+    let table_provider = Arc::new(ListingTable::try_new(config)?);
+    engine.register_table("test_table", table_provider)?;
+    println!("Registered test_table successfully from lib.rs.");
+
+    // Determine address: override if Some, else default.
+    let addr: SocketAddr = addr_override.unwrap_or_else(|| "127.0.0.1:50051".parse().unwrap());
+
+    let igloo_flight_service = IglooFlightSqlService::new(engine.clone());
+    let coordinator_service = CoordinatorFlightSqlService::new(igloo_flight_service);
+
+    println!("Flight SQL server (from lib.rs) listening on {}", addr);
+    Server::builder()
+        .add_service(FlightServiceServer::new(coordinator_service))
+        .serve_with_shutdown(addr, async {
+            tokio::signal::ctrl_c().await.expect("Failed to listen for CTRL+C signal");
+            println!("Shutting down Flight SQL server (from lib.rs)...");
+        })
+        .await?;
+
+    println!("Flight SQL server (from lib.rs) shut down gracefully.");
+    Ok(())
+}

--- a/crates/coordinator/src/main.rs
+++ b/crates/coordinator/src/main.rs
@@ -1,74 +1,14 @@
-use datafusion::arrow::datatypes::{DataType, Field, Schema};
-use datafusion::arrow::util::pretty::print_batches;
-use datafusion::datasource::file_format::csv::CsvFormat;
-use datafusion::datasource::listing::{
-    ListingOptions, ListingTable, ListingTableConfig, ListingTableUrl,
-};
-use igloo_engine::QueryEngine;
-use std::path::Path;
-use std::sync::Arc; // For path operations
-
-mod service;
-
-use arrow_flight::flight_service_server::FlightServiceServer;
-use igloo_api::IglooFlightSqlService;
-use std::net::SocketAddr;
-use tonic::transport::Server;
+use igloo_coordinator::launch_coordinator; // Use the function from the library
+use std::error::Error;
 
 #[tokio::main]
-async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    // 1. Instantiate the query engine
-    let engine = QueryEngine::new();
-
-    // 2. Register the CSV as a table
-    let csv_relative_path = "../connectors/filesystem/test_data.csv";
-    let base_path = std::env::current_dir()?; // Assuming run from workspace root
-    let csv_abs_path = base_path.join(Path::new(csv_relative_path));
-
-    let table_path_url_str = format!("file://{}", csv_abs_path.display());
-    let table_path = ListingTableUrl::parse(&table_path_url_str)?;
-
-    println!("Attempting to register test_table with path: {}", csv_abs_path.display());
-
-    let config = ListingTableConfig::new(table_path)
-        .with_schema(Arc::new(Schema::new(vec![
-            Field::new("col_a", DataType::Int64, false),
-            Field::new("col_b", DataType::Utf8, false),
-        ])))
-        .with_listing_options(
-            ListingOptions::new(Arc::new(CsvFormat::default().with_has_header(true)))
-                .with_file_extension(".csv"),
-        );
-
-    let table_provider = Arc::new(ListingTable::try_new(config)?);
-    engine.register_table("test_table", table_provider)?;
-    println!("Registered test_table successfully.");
-
-    // 3. Execute a simple query
-    let sql = "SELECT col_a, col_b FROM test_table LIMIT 5;";
-    println!("Executing SQL: {}", sql);
-    let results = engine.execute(sql).await;
-
-    // 4. Print results
-    println!("Query Results:");
-    match print_batches(&results) {
-        Ok(_) => {} // Already prints to stdout
-        Err(e) => eprintln!("Error printing batches: {}", e),
+async fn main() -> Result<(), Box<dyn Error>> {
+    println!("Coordinator binary starting...");
+    // Call the extracted function with no address override (uses default)
+    if let Err(e) = launch_coordinator(None).await {
+        eprintln!("Coordinator failed to launch: {}", e);
+        std::process::exit(1);
     }
-    println!("Finished printing query results.");
-
-    // Keep the existing Flight SQL server setup
-    let addr: SocketAddr = "127.0.0.1:50051".parse()?;
-    let flight_service = IglooFlightSqlService::new(engine.clone()); // engine is cloned
-    println!("Coordinator Flight SQL listening on {}", addr);
-
-    Server::builder()
-        .add_service(FlightServiceServer::new(flight_service))
-        .serve_with_shutdown(addr, async {
-            tokio::signal::ctrl_c().await.expect("failed to listen for event");
-            println!("Shutting down coordinator gracefully...");
-        })
-        .await?;
-
+    println!("Coordinator binary finished.");
     Ok(())
 }

--- a/crates/coordinator/tests/flight_server_integration.rs
+++ b/crates/coordinator/tests/flight_server_integration.rs
@@ -1,0 +1,85 @@
+use arrow_flight::flight_service_client::FlightServiceClient;
+use arrow_flight::{FlightDescriptor, FlightInfo, Ticket};
+use igloo_coordinator::launch_coordinator; // Assuming a helper function in main.rs or lib.rs
+use std::net::SocketAddr;
+use std::time::Duration;
+use tokio::task::JoinHandle;
+use tonic::transport::Channel;
+
+async fn start_test_server() -> (JoinHandle<Result<(), Box<dyn std::error::Error + Send + Sync>>>, SocketAddr) {
+    // Use a specific port for testing to simplify.
+    let test_addr: SocketAddr = "127.0.0.1:50052".parse().unwrap();
+
+    let server_handle = tokio::spawn(launch_coordinator(Some(test_addr)));
+    // Give the server a moment to start and bind the port
+    tokio::time::sleep(Duration::from_millis(500)).await;
+
+    (server_handle, test_addr) // Return the handle and the address it's supposed to listen on
+}
+
+#[tokio::test]
+async fn test_get_flight_info() {
+    let (server_handle, addr) = start_test_server().await;
+
+    // Connect to the server
+    let channel = Channel::from_shared(format!("http://{}", addr))
+        .unwrap()
+        .connect_timeout(Duration::from_secs(5))
+        .connect()
+        .await
+        .expect("Failed to connect to coordinator");
+    let mut client = FlightServiceClient::new(channel);
+
+    // Call get_flight_info
+    let request = FlightDescriptor::new_cmd("SELECT 1".as_bytes().to_vec());
+    let response = client.get_flight_info(request).await;
+
+    assert!(response.is_ok(), "get_flight_info failed: {:?}", response.err());
+    let flight_info = response.unwrap().into_inner();
+    // Basic assertion: check that a FlightInfo object is returned.
+    println!("Received FlightInfo: {:?}", flight_info);
+    assert!(!flight_info.endpoint.is_empty(), "No endpoints in FlightInfo");
+
+    // Cleanup: Abort the server task
+    server_handle.abort();
+}
+
+#[tokio::test]
+async fn test_do_get() {
+    let (server_handle, addr) = start_test_server().await;
+
+    // Connect to the server
+    let channel = Channel::from_shared(format!("http://{}", addr))
+        .unwrap()
+        .connect_timeout(Duration::from_secs(5))
+        .connect()
+        .await
+        .expect("Failed to connect to coordinator");
+    let mut client = FlightServiceClient::new(channel);
+
+    // First, call get_flight_info to get a ticket
+    let request_info = FlightDescriptor::new_cmd("SELECT 1".as_bytes().to_vec());
+    let flight_info_response = client.get_flight_info(request_info).await;
+    assert!(flight_info_response.is_ok(), "get_flight_info for do_get failed");
+    let flight_info = flight_info_response.unwrap().into_inner();
+    assert!(!flight_info.endpoint.is_empty(), "No endpoints in FlightInfo for do_get");
+    assert!(flight_info.endpoint[0].ticket.is_some(), "No ticket in FlightInfo endpoint for do_get");
+
+    let ticket = flight_info.endpoint[0].ticket.clone().unwrap();
+
+    // Call do_get
+    let response_stream = client.do_get(ticket).await;
+
+    assert!(response_stream.is_ok(), "do_get failed: {:?}", response_stream.err());
+    let mut flight_data_stream = response_stream.unwrap().into_inner();
+
+    // Basic assertion: try to receive at least one FlightData message
+    let data = flight_data_stream.message().await;
+    assert!(data.is_ok(), "Failed to receive message from do_get stream: {:?}", data.err());
+    assert!(data.unwrap().is_some(), "do_get stream ended prematurely or was empty");
+
+    println!("Received data from do_get stream");
+
+    // Cleanup: Abort the server task
+    server_handle.abort();
+}


### PR DESCRIPTION
This commit refines the Apache Arrow Flight SQL endpoint implementation within the `igloo-coordinator` crate.

Key changes include:
- Updated `Cargo.toml` with necessary dependencies (`futures`).
- Refactored `main.rs` for clearer server startup logic and basic logging.
- Introduced `CoordinatorFlightSqlService` in `service.rs` to encapsulate server-side Flight SQL handling, wrapping `IglooFlightSqlService` and adding logging for request reception.
- Restructured the `igloo-coordinator` crate into a library and binary to facilitate programmatic server startup for testing.
- Added integration tests in `tests/flight_server_integration.rs` that verify `get_flight_info` and `do_get` endpoint functionality by starting the coordinator and connecting with a Flight SQL client.

Note: I skipped the `./scripts/check.sh` verification step due to persistent errors related to package management (`apt-get`) in the execution environment, which prevented me from successfully running `setup.sh`. The implemented code changes are based on the requirements and my previous successful work.