### PR TITLE
feat: implement sql parser and initial logical plan

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -77,6 +77,56 @@ dependencies = [
 ]
 
 [[package]]
+name = "anstream"
+version = "0.6.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "301af1932e46185686725e0fad2f8f2aa7da69dd70bf6ecc44d6b703844a3933"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "862ed96ca487e809f1c8e5a8447f6ee2cf102f846893800b20cebdf541fc6bbd"
+
+[[package]]
+name = "anstyle-parse"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c8bdeb6047d8983be085bab0ba1472e6dc604e7041dbf6fcd5e71523014fae9"
+dependencies = [
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "403f75924867bb1033c59fbf0797484329750cfbe3c4325cd33127941fabc882"
+dependencies = [
+ "anstyle",
+ "once_cell_polyfill",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -626,6 +676,52 @@ dependencies = [
  "parse-zoneinfo",
  "phf_codegen",
 ]
+
+[[package]]
+name = "clap"
+version = "4.5.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40b6887a1d8685cebccf115538db5c0efe625ccac9696ad45c409d96566e910f"
+dependencies = [
+ "clap_builder",
+ "clap_derive",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.5.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0c66c08ce9f0c698cbce5c0279d0bb6ac936d8674174fe48f736533b964f59e"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.5.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2c7947ae4cc3d851207c1adb5b5e260ff0cca11446b1d6d1423788e442257ce"
+dependencies = [
+ "heck 0.5.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.103",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b94f61472cee1439c0b966b47e3aca9ae07e45d070759512cd390ea2bebc6675"
+
+[[package]]
+name = "colorchoice"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
 name = "comfy-table"
@@ -1894,6 +1990,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "igloo"
+version = "0.1.0"
+dependencies = [
+ "clap",
+ "igloo-api",
+ "igloo-cache",
+ "igloo-cdc",
+ "igloo-client",
+ "igloo-common",
+ "igloo-connector-filesystem",
+ "igloo-connector-mysql",
+ "igloo-connector-postgres",
+ "igloo-coordinator",
+ "igloo-engine",
+ "igloo-worker",
+ "tokio",
+]
+
+[[package]]
 name = "igloo-api"
 version = "0.1.0"
 dependencies = [
@@ -2025,6 +2140,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "igloo-sql"
+version = "0.1.0"
+dependencies = [
+ "igloo-common",
+ "sqlparser 0.45.0",
+]
+
+[[package]]
 name = "igloo-worker"
 version = "0.1.0"
 dependencies = [
@@ -2063,6 +2186,12 @@ name = "integer-encoding"
 version = "3.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8bb03732005da905c88227371639bf1ad885cc712789c011c31c5fb3ab3ccf02"
+
+[[package]]
+name = "is_terminal_polyfill"
+version = "1.70.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
 
 [[package]]
 name = "itertools"
@@ -2434,6 +2563,12 @@ name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+
+[[package]]
+name = "once_cell_polyfill"
+version = "1.70.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4895175b425cb1f87721b59f0f286c2092bd4af812243672510e1ac53e2e0ad"
 
 [[package]]
 name = "ordered-float"
@@ -3045,6 +3180,15 @@ dependencies = [
 
 [[package]]
 name = "sqlparser"
+version = "0.45.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7bbffee862a796d67959a89859d6b1046bb5016d63e23835ad0da182777bbe0"
+dependencies = [
+ "log",
+]
+
+[[package]]
+name = "sqlparser"
 version = "0.55.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4521174166bac1ff04fe16ef4524c70144cd29682a45978978ca3d7f4e0be11"
@@ -3099,6 +3243,12 @@ name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "subtle"
@@ -3434,6 +3584,12 @@ name = "utf8_iter"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+
+[[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ members = [
     "crates/connectors/filesystem",
     "crates/igloo", # Added the new main igloo crate
     "pyigloo"
-]
+, "crates/sql"]
 resolver = "2"
 
 [workspace.dependencies]

--- a/crates/common/src/catalog.rs
+++ b/crates/common/src/catalog.rs
@@ -2,8 +2,26 @@ use datafusion::datasource::TableProvider;
 use std::collections::HashMap;
 use std::sync::Arc;
 
+// Basic Schema definition for now
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Schema {
+    // In a real system, this would contain column definitions (name, type, etc.)
+    // For now, an empty struct is sufficient as a placeholder.
+    // We can compare Arc<Schema> directly.
+}
+
+impl Schema {
+    pub fn empty() -> Self {
+        Self {}
+    }
+}
+
+pub type SchemaRef = Arc<Schema>;
+
 pub struct MemoryCatalog {
     pub tables: HashMap<String, Arc<dyn TableProvider>>,
+    // We might want to store schemas here later, but for now,
+    // the planner creates dummy schemas.
 }
 
 impl Default for MemoryCatalog {
@@ -14,7 +32,9 @@ impl Default for MemoryCatalog {
 
 impl MemoryCatalog {
     pub fn new() -> Self {
-        Self { tables: HashMap::new() }
+        Self {
+            tables: HashMap::new(),
+        }
     }
 
     pub fn register_table(&mut self, name: String, provider: Arc<dyn TableProvider>) {

--- a/crates/common/src/error.rs
+++ b/crates/common/src/error.rs
@@ -7,8 +7,12 @@ use sqlparser::parser::ParserError;
 pub enum Error {
     #[error("An unknown error occurred: {0}")]
     Unknown(String),
-    // Add more error variants as needed
     #[error("SQL parsing error: {0}")]
+    Parse(String), // Changed from SqlParser(#[from] ParserError) to match usage
+    #[error("Planning error: {0}")]
+    Plan(String),
+    // Add more error variants as needed
+    #[error("SQL parser error: {0}")] // Kept a separate variant for direct sqlparser errors if needed elsewhere
     SqlParser(#[from] ParserError),
 }
 

--- a/crates/common/src/lib.rs
+++ b/crates/common/src/lib.rs
@@ -11,4 +11,6 @@
 
 pub mod catalog;
 pub mod error;
+
+pub use catalog::{Schema, SchemaRef}; // Added Schema and SchemaRef
 pub use error::Error;

--- a/crates/sql/Cargo.toml
+++ b/crates/sql/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "igloo-sql"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+sqlparser = "0.45.0"
+igloo-common = { path = "../common" }

--- a/crates/sql/src/lib.rs
+++ b/crates/sql/src/lib.rs
@@ -1,0 +1,5 @@
+pub mod logical_plan;
+pub mod planner;
+
+pub use logical_plan::{LogicalExpr, LogicalPlan};
+pub use planner::Planner;

--- a/crates/sql/src/logical_plan.rs
+++ b/crates/sql/src/logical_plan.rs
@@ -1,0 +1,18 @@
+use igloo_common::catalog::SchemaRef;
+
+#[derive(Debug, PartialEq, Clone)]
+pub enum LogicalPlan {
+    Projection {
+        expr: Vec<LogicalExpr>,
+        input: Box<LogicalPlan>,
+    },
+    TableScan {
+        table_name: String,
+        projected_schema: SchemaRef,
+    },
+}
+
+#[derive(Debug, PartialEq, Clone)]
+pub enum LogicalExpr {
+    Column { name: String },
+}

--- a/crates/sql/src/planner.rs
+++ b/crates/sql/src/planner.rs
@@ -1,0 +1,101 @@
+use crate::logical_plan::{LogicalExpr, LogicalPlan};
+use igloo_common::{catalog::Schema, error::Error};
+use sqlparser::{
+    ast::{Ident, Query, SelectItem, SetExpr, Statement, TableFactor},
+    dialect::GenericDialect,
+    parser::Parser,
+};
+use std::sync::Arc;
+
+#[derive(Default)]
+pub struct Planner {}
+
+impl Planner {
+    pub fn new() -> Self {
+        Self {}
+    }
+
+    pub fn sql_to_logical_plan(&self, sql: &str) -> Result<LogicalPlan, Error> {
+        let dialect = GenericDialect {};
+        let statements = Parser::parse_sql(&dialect, sql)
+            .map_err(|e| Error::Parse(e.to_string()))?;
+
+        if statements.len() != 1 {
+            return Err(Error::Plan(
+                "Exactly one statement is required".to_string(),
+            ));
+        }
+
+        self.statement_to_logical_plan(statements[0].clone())
+    }
+
+    fn statement_to_logical_plan(&self, statement: Statement) -> Result<LogicalPlan, Error> {
+        match statement {
+            Statement::Query(query) => self.query_to_logical_plan(*query),
+            _ => Err(Error::Plan(
+                "Unsupported SQL statement type".to_string(),
+            )),
+        }
+    }
+
+    fn query_to_logical_plan(&self, query: Query) -> Result<LogicalPlan, Error> {
+        let Query { body, .. } = query;
+        match *body {
+            SetExpr::Select(select) => {
+                let table_scan = if let Some(from_table) = select.from.get(0) {
+                    match &from_table.relation {
+                        TableFactor::Table { name, .. } => {
+                            let table_name = name.0.get(0).map_or_else(
+                                || Err(Error::Plan("Table name not found".to_string())),
+                                |ident| Ok(ident.value.clone()),
+                            )?;
+                            // Dummy schema for now
+                            let dummy_schema = Arc::new(Schema::empty());
+                            LogicalPlan::TableScan {
+                                table_name,
+                                projected_schema: dummy_schema,
+                            }
+                        }
+                        _ => {
+                            return Err(Error::Plan(
+                                "Unsupported table factor in FROM clause".to_string(),
+                            ))
+                        }
+                    }
+                } else {
+                    return Err(Error::Plan("FROM clause is required".to_string()));
+                };
+
+                let projection_exprs: Vec<LogicalExpr> = select
+                    .projection
+                    .into_iter()
+                    .map(|item| match item {
+                        SelectItem::UnnamedExpr(expr) => match expr {
+                            sqlparser::ast::Expr::Identifier(Ident { value, .. }) => {
+                                Ok(LogicalExpr::Column { name: value })
+                            }
+                            _ => Err(Error::Plan(
+                                "Unsupported expression in SELECT".to_string(),
+                            )),
+                        },
+                        SelectItem::ExprWithAlias { expr, alias } => match expr {
+                            sqlparser::ast::Expr::Identifier(Ident { .. }) => { // value removed
+                                Ok(LogicalExpr::Column { name: alias.value }) // Use alias if available
+                            }
+                            _ => Err(Error::Plan(
+                                "Unsupported aliased expression in SELECT".to_string(),
+                            )),
+                        },
+                        _ => Err(Error::Plan("Unsupported SELECT item".to_string())),
+                    })
+                    .collect::<Result<Vec<LogicalExpr>, Error>>()?;
+
+                Ok(LogicalPlan::Projection {
+                    expr: projection_exprs,
+                    input: Box::new(table_scan),
+                })
+            }
+            _ => Err(Error::Plan("Unsupported query type".to_string())),
+        }
+    }
+}

--- a/crates/sql/tests/planner.rs
+++ b/crates/sql/tests/planner.rs
@@ -1,0 +1,127 @@
+use igloo_common::catalog::Schema;
+use igloo_sql::{LogicalExpr, LogicalPlan, Planner};
+use std::sync::Arc;
+
+#[test]
+fn test_simple_select() {
+    let planner = Planner::new();
+    let sql = "SELECT col1, col2 FROM my_table;";
+    let result = planner.sql_to_logical_plan(sql);
+
+    assert!(result.is_ok());
+    let plan = result.unwrap();
+
+    let expected_schema = Arc::new(Schema::empty()); // Dummy schema
+
+    if let LogicalPlan::Projection { expr, input } = plan {
+        assert_eq!(expr.len(), 2);
+        assert_eq!(expr[0], LogicalExpr::Column { name: "col1".to_string() });
+        assert_eq!(expr[1], LogicalExpr::Column { name: "col2".to_string() });
+
+        if let LogicalPlan::TableScan { table_name, projected_schema } = *input {
+            assert_eq!(table_name, "my_table");
+            assert_eq!(projected_schema, expected_schema);
+        } else {
+            panic!("Input to Projection should be a TableScan");
+        }
+    } else {
+        panic!("Expected a Projection plan");
+    }
+}
+
+#[test]
+fn test_select_with_alias() {
+    let planner = Planner::new();
+    let sql = "SELECT a AS b FROM my_table;";
+    let result = planner.sql_to_logical_plan(sql);
+
+    assert!(result.is_ok());
+    let plan = result.unwrap();
+
+    if let LogicalPlan::Projection { expr, .. } = plan {
+        assert_eq!(expr.len(), 1);
+        assert_eq!(expr[0], LogicalExpr::Column { name: "b".to_string() });
+    } else {
+        panic!("Expected a Projection plan");
+    }
+}
+
+
+#[test]
+fn test_invalid_sql() {
+    let planner = Planner::new();
+    let sql = "SELECT FROM my_table;"; // Invalid SQL syntax
+    let result = planner.sql_to_logical_plan(sql);
+    assert!(result.is_err());
+    if let Err(e) = result {
+        // sqlparser-rs parses "SELECT FROM my_table" as SELECT "FROM" AS "my_table" (no FROM clause)
+        // Our planner then correctly identifies that the FROM clause is missing.
+        assert_eq!(e.to_string(), "Planning error: FROM clause is required");
+    }
+}
+
+#[test]
+fn test_unsupported_statement_insert() {
+    let planner = Planner::new();
+    let sql = "INSERT INTO my_table (col1) VALUES (1);";
+    let result = planner.sql_to_logical_plan(sql);
+    assert!(result.is_err());
+    if let Err(e) = result {
+        assert_eq!(e.to_string(), "Planning error: Unsupported SQL statement type");
+    }
+}
+
+#[test]
+fn test_unsupported_statement_create() {
+    let planner = Planner::new();
+    let sql = "CREATE TABLE my_table (col1 INT);";
+    let result = planner.sql_to_logical_plan(sql);
+    assert!(result.is_err());
+    if let Err(e) = result {
+        assert_eq!(e.to_string(), "Planning error: Unsupported SQL statement type");
+    }
+}
+
+#[test]
+fn test_multiple_statements() {
+    let planner = Planner::new();
+    let sql = "SELECT col1 FROM table1; SELECT col2 FROM table2;";
+    let result = planner.sql_to_logical_plan(sql);
+    assert!(result.is_err());
+    if let Err(e) = result {
+        assert_eq!(e.to_string(), "Planning error: Exactly one statement is required");
+    }
+}
+
+#[test]
+fn test_no_from_clause() {
+    let planner = Planner::new();
+    let sql = "SELECT col1;";
+    let result = planner.sql_to_logical_plan(sql);
+    assert!(result.is_err());
+    if let Err(e) = result {
+        assert_eq!(e.to_string(), "Planning error: FROM clause is required");
+    }
+}
+
+#[test]
+fn test_unsupported_select_item() {
+    let planner = Planner::new();
+    let sql = "SELECT * FROM my_table;"; // Wildcard not yet supported
+    let result = planner.sql_to_logical_plan(sql);
+    assert!(result.is_err());
+    if let Err(e) = result {
+        assert_eq!(e.to_string(), "Planning error: Unsupported SELECT item");
+    }
+}
+
+#[test]
+fn test_unsupported_table_factor() {
+    let planner = Planner::new();
+    let sql = "SELECT col1 FROM (SELECT col2 FROM table2);"; // Subquery in FROM
+    let result = planner.sql_to_logical_plan(sql);
+    assert!(result.is_err());
+    if let Err(e) = result {
+        assert_eq!(e.to_string(), "Planning error: Unsupported table factor in FROM clause");
+    }
+}


### PR DESCRIPTION
This commit introduces the `igloo-sql` crate, which provides functionality to parse SQL queries and convert them into a logical plan representation.

Key changes:
- Added `igloo-sql` crate with `sqlparser` and `igloo-common` dependencies.
- Defined `LogicalPlan` and `LogicalExpr` enums for representing query plans.
- Implemented a `Planner` to convert SQL AST (from `sqlparser-rs`) into `LogicalPlan`.
  - Currently supports simple `SELECT col1, col2 FROM table_name` queries.
  - Uses a dummy schema for `TableScan` for now.
- Added integration tests for the planner, covering:
  - Simple SELECT queries.
  - Aliased columns.
  - Invalid SQL syntax (handled by planner due to sqlparser's leniency).
  - Unsupported statements (INSERT, CREATE).
  - Multiple statements.
  - Missing FROM clause.
  - Unsupported SELECT items (e.g., `SELECT *`).
  - Unsupported table factors (e.g., subqueries in FROM).
- Updated `igloo-common`:
  - Added basic `Schema` and `SchemaRef` types.
  - Added `Parse` and `Plan` variants to the `Error` enum.